### PR TITLE
Fix email imports and build configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "1.9.23"
+    kotlin("plugin.serialization") version "1.9.23"
     application
 }
 
@@ -17,6 +18,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1") // JSON parsing
     implementation("org.json:json:20240303")
     implementation("com.sun.mail:jakarta.mail:2.0.1") // Email functionality
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }
 
 application {
@@ -24,7 +26,8 @@ application {
 }
 
 kotlin {
-    jvmToolchain(17) // Changed from 21 to 17 for better Render compatibility
+    // Use the available JDK
+    jvmToolchain(21)
 }
 
 // Disable tests to prevent build failures

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,9 +1,9 @@
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
-import javax.mail.*
-import javax.mail.internet.InternetAddress
-import javax.mail.internet.MimeMessage
+import jakarta.mail.*
+import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeMessage
 import kotlin.system.exitProcess
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document


### PR DESCRIPTION
## Summary
- use the jakarta.mail package in Main.kt
- enable kotlinx serialization plugin and library
- target the available JDK 21

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6866424c1f788322935762f4e95ffc10