### PR TITLE
Fix serialization and env setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-# Install gradle
-RUN apk add --no-cache gradle
+# Install gradle and git for pushing updates
+RUN apk add --no-cache gradle git
+
+# Environment variables will be injected by Render
+ARG OPENAI_API_KEY
+ARG EMAIL_USER
+ARG EMAIL_PASS
+
+ENV OPENAI_API_KEY=${OPENAI_API_KEY}
+ENV EMAIL_USER=${EMAIL_USER}
+ENV EMAIL_PASS=${EMAIL_PASS}
 
 COPY . /app
 WORKDIR /app

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -91,7 +91,8 @@ class NewsAggregator {
                 )
             )
 
-            val jsonBody = Json.encodeToString(request)
+            // Explicitly specify serializer to avoid runtime issues
+            val jsonBody = Json.encodeToString(ChatRequest.serializer(), request)
 
             val conn = URL("https://api.openai.com/v1/chat/completions").openConnection() as HttpURLConnection
             conn.requestMethod = "POST"


### PR DESCRIPTION
## Summary
- fix runtime serialization by explicitly using ChatRequest serializer
- include git and environment variables in Dockerfile for Render

## Testing
- `./gradlew clean build`
- `./gradlew run --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68664e871d008322beda79fb009d9ce9