### PR TITLE
Improve GitHub publishing via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Set the required environment variables before running:
 
 - `OPENAI_API_KEY` – optional, used for generating summaries and translations.
 - `EMAIL_USER` / `EMAIL_PASS` / `TO_EMAIL` – optional, enable email notifications.
+- `GITHUB_TOKEN` – optional, enables pushing the generated blog via the GitHub API.
 
 Run the aggregator with:
 


### PR DESCRIPTION
## Summary
- support pushing the generated blog to the gist using the GitHub API
- document optional `GITHUB_TOKEN` variable

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686668d46ff0832281ac4b1f14b3903b