### PR TITLE
Improve fallback summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ This compiles the Kotlin sources and ensures dependencies are downloaded.
 
 ## Running
 
-Set the required environment variables before running:
+-Set the required environment variables before running:
 
-- `OPENAI_API_KEY` – optional, used for generating summaries and translations.
+- `OPENAI_API_KEY` – optional, used for generating summaries and translations. If not set, the first sentence of each article will be used as the summary.
 - `EMAIL_USER` / `EMAIL_PASS` / `TO_EMAIL` – optional, enable email notifications.
 - `GITHUB_TOKEN` – optional, enables pushing the generated blog via the GitHub API.
 

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -64,12 +64,21 @@ class NewsAggregator {
     private fun translateSummaryFromContent(text: String): Map<String, String> {
         val content = text.take(2000)
         val response = openAiTranslate(content)
-        return response ?: mapOf(
-            "en" to "General news story relevant to Cyprus current affairs.",
+        if (response != null) return response
+
+        val simple = extractFirstSentence(content)
+        return mapOf(
+            "en" to simple,
             "he" to "חדשות כלליות מקפריסין.",
             "ru" to "Актуальные новости Кипра.",
             "el" to "Γενικές ειδήσεις που σχετίζονται με την Κύπρο."
         )
+    }
+
+    private fun extractFirstSentence(text: String): String {
+        val sentenceEnd = Regex("(?<=[.!?])\\s+")
+        val first = sentenceEnd.split(text).firstOrNull()?.trim()
+        return first?.take(150) ?: text.take(150)
     }
 
     private fun openAiTranslate(content: String): Map<String, String>? {


### PR DESCRIPTION
## Summary
- handle missing OpenAI key by summarizing the first sentence of each article
- document the new fallback behaviour in the README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68666dcafd848322b7a2252f199f359d