### PR TITLE
Add fallback translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,22 @@ Run the aggregator with:
 
 The script will scrape news, generate `index.html`, push it to the configured Gist and send an email if credentials are provided.
 
+The optional translation helper under `scripts/translate.py` requires the Python package `googletrans`:
+
+```sh
+pip install googletrans==4.0.0-rc1
+```
+
+If summaries remain in English, ensure the package is installed or provide an
+`OPENAI_API_KEY` so the script can fall back to OpenAI's translation API.
+
 ## Repository Layout
 
 - `src/main/kotlin` – application source
 - `build.gradle.kts` – build configuration
 - `seen_articles.json` – remembers which URLs were already processed
 
+
+## Language Support
+
+The generated HTML page now includes a language selector for English, Hebrew, Russian and Greek. Summaries are translated using the Python `googletrans` library when no OpenAI API key is provided. Selecting a language also changes the "Read more" links to open via Google Translate.

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -1,0 +1,7 @@
+import sys
+from googletrans import Translator
+
+text = sys.argv[1]
+lang = sys.argv[2]
+translator = Translator()
+print(translator.translate(text, dest=lang).text)

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -61,17 +61,36 @@ class NewsAggregator {
         }
     }
 
+    private fun googleTranslate(text: String, lang: String): String? {
+        return try {
+            val process = ProcessBuilder(
+                "python3",
+                "scripts/translate.py",
+                text,
+                lang
+            ).start()
+            val result = process.inputStream.bufferedReader().readText().trim()
+            if (process.waitFor() == 0) result else null
+        } catch (e: Exception) {
+            println("⚠️ Local translation failed: ${e.message}")
+            null
+        }
+    }
+
     private fun translateSummaryFromContent(text: String): Map<String, String> {
         val content = text.take(2000)
         val response = openAiTranslate(content)
         if (response != null) return response
 
         val simple = extractFirstSentence(content)
+        val he = googleTranslate(simple, "he") ?: simple
+        val ru = googleTranslate(simple, "ru") ?: simple
+        val el = googleTranslate(simple, "el") ?: simple
         return mapOf(
             "en" to simple,
-            "he" to "חדשות כלליות מקפריסין.",
-            "ru" to "Актуальные новости Кипра.",
-            "el" to "Γενικές ειδήσεις που σχετίζονται με την Κύπρο."
+            "he" to he,
+            "ru" to ru,
+            "el" to el
         )
     }
 
@@ -81,6 +100,14 @@ class NewsAggregator {
         return first?.take(150) ?: text.take(150)
     }
 
+    private fun escapeHtml(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&#39;")
+    }
     private fun openAiTranslate(content: String): Map<String, String>? {
         val apiKey = System.getenv("OPENAI_API_KEY")
         if (apiKey.isNullOrBlank()) {
@@ -132,6 +159,14 @@ class NewsAggregator {
         }
     }
 
+    private fun cleanArticleText(raw: String): String {
+        return raw.lines()
+            .filterNot { it.contains("Newsletter", ignoreCase = true) || it.contains("Language", ignoreCase = true) }
+            .joinToString(" ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+    }
+
     private fun scrapeNewsSource(name: String, url: String): List<Article> {
         println("🔍 Scraping $name")
         val doc = fetchPage(url) ?: return emptyList()
@@ -144,12 +179,14 @@ class NewsAggregator {
         println("🔗 [$name] Found ${links.size} candidate links")
 
         val articles = mutableListOf<Article>()
+        val titles = mutableSetOf<String>()
         links.forEach { link ->
             if (seen.contains(link)) return@forEach
             try {
                 val page = Jsoup.connect(link).get()
                 val title = page.title().take(140)
-                val articleText = page.select("p").joinToString(" ") { it.text() }.take(2000)
+                if (titles.contains(title)) return@forEach
+                val articleText = cleanArticleText(page.select("p").joinToString(" ") { it.text() }).take(2000)
 
                 if (articleText.isBlank()) {
                     println("⚠️ Empty article body for $link – skipping")
@@ -170,6 +207,7 @@ class NewsAggregator {
                     )
                 )
                 seen.add(link)
+                titles.add(title)
             } catch (e: Exception) {
                 println("❌ Error scraping $link: ${e.message}")
             }
@@ -191,21 +229,29 @@ class NewsAggregator {
 
     fun generateHtmlBlog(articles: List<Article>): String {
         val date = SimpleDateFormat("yyyy-MM-dd").format(Date())
+
         val builder = StringBuilder()
         builder.append("<html><head><meta charset='utf-8'><title>Weekly Cyprus Blog – $date</title></head><body>")
         builder.append("<h1>Weekly Cyprus Blog – $date</h1>")
+        builder.append("<label for='lang'>Language:</label>")
+        builder.append("<select id='lang'><option value='en'>English</option><option value='he'>עברית</option><option value='ru'>Русский</option><option value='el'>Ελληνικά</option></select>")
         articles.forEach {
-            builder.append("<h2>${it.title}</h2>")
-            builder.append("<p>${it.translations["en"]}</p>")
-            builder.append("<p><strong>HE:</strong> ${it.translations["he"]}</p>")
-            builder.append("<p><strong>RU:</strong> ${it.translations["ru"]}</p>")
-            builder.append("<p><strong>EL:</strong> ${it.translations["el"]}</p>")
-            builder.append("<p><a href='${it.url}' target='_blank'>Read more</a></p><hr>")
+            val title = escapeHtml(it.title)
+            val en = escapeHtml(it.translations["en"] ?: "")
+            val he = escapeHtml(it.translations["he"] ?: "")
+            val ru = escapeHtml(it.translations["ru"] ?: "")
+            val el = escapeHtml(it.translations["el"] ?: "")
+            val url = it.url
+            builder.append("<div class='article'>")
+            builder.append("<h2>$title</h2>")
+            builder.append("<p class='summary' data-en='$en' data-he='$he' data-ru='$ru' data-el='$el'></p>")
+            builder.append("<p><a class='read-more' data-url='$url' target='_blank'>Read more</a></p><hr>")
+            builder.append("</div>")
         }
+        builder.append("<script>const sel=document.getElementById('lang');function upd(){const l=sel.value;document.querySelectorAll('.summary').forEach(p=>{p.textContent=p.dataset[l]||''});document.querySelectorAll('.read-more').forEach(a=>{a.href='https://translate.google.com/translate?hl='+l+'&u='+encodeURIComponent(a.dataset.url)});}sel.addEventListener('change',upd);upd();</script>")
         builder.append("</body></html>")
         return builder.toString()
     }
-
     private fun pushViaGistApi(filename: String, html: String, gistId: String): String {
         val token = System.getenv("GITHUB_TOKEN") ?: return ""
 


### PR DESCRIPTION
## Summary
- improve fallback behaviour when translations fail
- warn if local translation script can't run
- note how to get translations working

## Testing
- `./gradlew build`
- `./gradlew run` *(fails to fetch articles due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686671dccf788322add624939af25ed5